### PR TITLE
Get new blob boundaries without creating new blobs

### DIFF
--- a/inc/WireCellSpng/RayTiling.h
+++ b/inc/WireCellSpng/RayTiling.h
@@ -207,6 +207,18 @@ namespace WireCell::Spng::RayGrid {
                    const torch::Tensor& activity);
 
 
+    /**
+     * @brief Applies activity to blobs to make new blobs with one more view.
+     * @param coords The Coordinates object.
+     * @param blobs The existing blobs tensor.
+     * @param activity A 1D boolean tensor representing the new view's activity.
+     * @return The half-open bounds which correspond to the new blobs which would be 
+     * returned -- this is used within apply_activity
+     */
+    std::tuple<torch::Tensor, torch::Tensor>
+    retrieve_new_blob_bounds(const Coordinates& coords, const torch::Tensor& blobs,
+                        const torch::Tensor& activity);
+
 } // namespace WireCell::Spng::RayGrid
 
 #endif // WIRECELL_SPNG_RAYGRID_RAYTILING_H

--- a/src/RayTiling.cxx
+++ b/src/RayTiling.cxx
@@ -432,6 +432,16 @@ namespace WireCell::Spng::RayGrid {
     torch::Tensor
     apply_activity(const Coordinates& coords, const torch::Tensor& blobs_in,
                    const torch::Tensor& activity) {
+        torch::Tensor lo, hi;
+        std::tie(lo, hi) = retrieve_new_blob_bounds(coords, blobs_in, activity);
+        torch::Tensor new_blobs = expand_blobs_with_activity(blobs_in, lo, hi, activity);
+
+        return new_blobs;
+    }
+
+    std::tuple<torch::Tensor, torch::Tensor>
+    retrieve_new_blob_bounds(const Coordinates& coords, const torch::Tensor& blobs_in,
+                        const torch::Tensor& activity) {
         long nviews = blobs_in.size(1);
 
         torch::Tensor crossings = blob_crossings(blobs_in);
@@ -439,10 +449,9 @@ namespace WireCell::Spng::RayGrid {
         torch::Tensor lo, hi;
         std::tie(lo, hi) = blob_bounds(coords, crossings, nviews, insides);
 
-        std::tie(lo, hi) = bounds_clamp(lo, hi, activity.size(0));
-        torch::Tensor new_blobs = expand_blobs_with_activity(blobs_in, lo, hi, activity);
+        auto results = bounds_clamp(lo, hi, activity.size(0));
 
-        return new_blobs;
+        return results;
     }
 
 


### PR DESCRIPTION
Added new method that retrieves bounds from activity in some layer applied to previously-made blobs. This is the majority of the operations within 'apply_activity' (which now uses this method)

This serves to isolate some of the behavior from Tiling as discussed in  #9 